### PR TITLE
feat:  add new rule use-router-from-next-intl as per the next-intl docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,11 @@ Lastly extend in your `eslintrc`
 ✅ Set in the `recommended` configuration.\
 🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).
 
-| Name                                                                                 | Description                                                    | 💼   | 🔧 |
-| :----------------------------------------------------------------------------------- | :------------------------------------------------------------- | :--- | :- |
-| [no-dynamic-translation-key](docs/rules/no-dynamic-translation-key.md)               | Enforce using static strings as keys for translation functions | 🌐 ✅ |    |
-| [use-next-intl-link-over-next-link](docs/rules/use-next-intl-link-over-next-link.md) | Replace next/link imports with next-intl/link imports          | 🌐 ✅ | 🔧 |
+| Name                                                                                 | Description                                                          | 💼   | 🔧 |
+| :----------------------------------------------------------------------------------- | :------------------------------------------------------------------- | :--- | :- |
+| [no-dynamic-translation-key](docs/rules/no-dynamic-translation-key.md)               | Enforce using static strings as keys for translation functions       | 🌐 ✅ |    |
+| [use-next-intl-link-over-next-link](docs/rules/use-next-intl-link-over-next-link.md) | Replace next/link imports with next-intl/link imports                | 🌐 ✅ | 🔧 |
+| [use-router-from-next-intl](docs/rules/use-router-from-next-intl.md)                 | Use `useRouter` from `next-intl/client` instead of `next/navigation` |      | 🔧 |
 
 <!-- end auto-generated rules list -->
 

--- a/docs/rules/use-router-from-next-intl.md
+++ b/docs/rules/use-router-from-next-intl.md
@@ -1,0 +1,26 @@
+# Use `useRouter` from `next-intl/client` instead of `next/navigation` (`next-intl/use-router-from-next-intl`)
+
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
+
+[`next-intl`'s API docs](https://next-intl-docs.vercel.app/docs/routing/navigation#userouter) suggests using their version of `useRouter` over the next provided one to automatically apply the locale of the user.
+
+Ref:
+
+> If you need to navigate programmatically, e.g. in an event handler, next-intl provides a convience API that wraps useRouter from Next.js(opens in a new tab) and automatically applies the locale of the user.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```ts
+import { useRouter, usePathname } from "next/navigation";
+```
+
+Examples of **correct** code for this rule:
+
+```ts
+import { useRouter } from "next-intl/client";
+import { useRouter, usePathname } from "next-intl/client";
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { noDynamicTranslationKey } from "./rules/no-dynamic-translation-key";
 import { useNextIntlLinkOverNextLink } from "./rules/use-next-intl-link-over-next-link";
+import { useRouterFromNextIntl } from "./rules/use-router-from-next-intl";
 import { name, version } from "../package.json";
 import { configAll } from "./configs/all";
 import { configRecommended } from "./configs/recommended";
@@ -12,6 +13,7 @@ export = {
   rules: {
     "no-dynamic-translation-key": noDynamicTranslationKey,
     "use-next-intl-link-over-next-link": useNextIntlLinkOverNextLink,
+    "use-router-from-next-intl": useRouterFromNextIntl,
   },
   configs: {
     all: configAll,

--- a/src/rules/use-router-from-next-intl.test.ts
+++ b/src/rules/use-router-from-next-intl.test.ts
@@ -1,0 +1,29 @@
+import { RuleTester } from "eslint";
+
+import {
+  useRouterFromNextIntl,
+  ERROR_MESSAGE as message,
+} from "./use-router-from-next-intl";
+
+const tester = new RuleTester({
+  parserOptions: { ecmaVersion: 2015, sourceType: "module" },
+});
+
+tester.run("use-router-from-next-intl", useRouterFromNextIntl, {
+  valid: [
+    { code: `import { useRouter } from 'next-intl/client';` },
+    { code: `import { useRouter, usePathname } from 'next-intl/client';` },
+  ],
+  invalid: [
+    {
+      code: `import { useRouter } from 'next/navigation';`,
+      errors: [{ message }],
+      output: `import { useRouter } from 'next-intl/client';`,
+    },
+    {
+      code: `import { useRouter, usePathname } from 'next/navigation';`,
+      errors: [{ message }],
+      output: `import { useRouter, usePathname } from 'next-intl/client';`,
+    },
+  ],
+});

--- a/src/rules/use-router-from-next-intl.ts
+++ b/src/rules/use-router-from-next-intl.ts
@@ -1,0 +1,40 @@
+export const ERROR_MESSAGE =
+  "Use 'useRouter' from 'next-intl/client' to automatically apply the locale";
+
+import { Rule } from "eslint";
+
+const meta: Rule.RuleMetaData = {
+  docs: {
+    description:
+      "Use `useRouter` from `next-intl/client` instead of `next/navigation`",
+    category: "Best Practices",
+    recommended: true,
+  },
+  fixable: "code",
+};
+
+export const useRouterFromNextIntl: Rule.RuleModule = {
+  meta,
+  create: (context) => {
+    return {
+      ImportDeclaration(node) {
+        if (node.source?.value === "next/navigation") {
+          const useRouterSpecifier = node.specifiers.find(
+            (specifier) =>
+              "imported" in specifier &&
+              specifier.imported.name === "useRouter",
+          );
+          if (useRouterSpecifier) {
+            context.report({
+              node,
+              message: ERROR_MESSAGE,
+              fix: function (fixer) {
+                return fixer.replaceText(node.source, "'next-intl/client'");
+              },
+            });
+          }
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
[`next-intl`'s API docs](https://next-intl-docs.vercel.app/docs/routing/navigation#userouter) suggests using their version of `useRouter` over the next provided one to automatically apply the locale of the user.