### PR TITLE
fix: allow empty argument for useTranslations

### DIFF
--- a/docs/rules/no-dynamic-translation-key.md
+++ b/docs/rules/no-dynamic-translation-key.md
@@ -25,6 +25,8 @@ Examples of **correct** code for this rule:
 ```ts
 t("key");
 
+useTranslations();
+
 useTranslations("key");
 
 t("Hi {{user}}!", { name: "User" });

--- a/src/rules/no-dynamic-translation-key.test.ts
+++ b/src/rules/no-dynamic-translation-key.test.ts
@@ -10,6 +10,7 @@ tester.run("no-dynamic-translation-key", noDynamicTranslationKey, {
     { code: 'useTranslations("key");' },
     { code: 't("Hi {{user}}!", { name: "User" });' },
     { code: "t(`errorMessage`);" },
+    { code: "useTranslations()" },
   ],
   invalid: [
     {

--- a/src/rules/no-dynamic-translation-key.ts
+++ b/src/rules/no-dynamic-translation-key.ts
@@ -48,6 +48,10 @@ export const noDynamicTranslationKey: Rule.RuleModule = {
 
         const [firstArgument] = node.arguments;
 
+        if (firstArgument === undefined && calleeName === "useTranslations") {
+          return;
+        }
+
         switch (firstArgument.type) {
           case "Literal":
             return;


### PR DESCRIPTION
`useTranslations()` can be used to get all available messages, screenshot from https://next-intl-docs.vercel.app/docs/usage/messages

<img width="870" alt="image" src="https://github.com/user-attachments/assets/833e5e0b-c136-4317-afa8-665bf73aa087">
